### PR TITLE
Dump original requests with the responses

### DIFF
--- a/hishel/_async/_pool.py
+++ b/hishel/_async/_pool.py
@@ -31,10 +31,12 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
 
     async def handle_async_request(self, request: Request) -> Response:
         key = generate_key(request)
-        stored_resposne, stored_request = await self._storage.retreive(key)
+        stored_data = await self._storage.retreive(key)
 
-        if stored_resposne:
+        if stored_data:
             # Try using the stored response if it was discovered.
+
+            stored_resposne, stored_request = stored_data
 
             res = self._controller.construct_response_from_cache(
                 request=request, response=stored_resposne
@@ -56,7 +58,7 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
                 )
 
                 await full_response.aread()
-                await self._storage.store(key, response=response, request=request)
+                await self._storage.store(key, response=full_response, request=request)
                 full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
                 return full_response
 

--- a/hishel/_async/_pool.py
+++ b/hishel/_async/_pool.py
@@ -31,7 +31,7 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
 
     async def handle_async_request(self, request: Request) -> Response:
         key = generate_key(request)
-        stored_resposne = await self._storage.retreive(key)
+        stored_resposne, stored_request = await self._storage.retreive(key)
 
         if stored_resposne:
             # Try using the stored response if it was discovered.
@@ -56,7 +56,7 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
                 )
 
                 await full_response.aread()
-                await self._storage.store(key, full_response)
+                await self._storage.store(key, response=response, request=request)
                 full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
                 return full_response
 
@@ -64,7 +64,7 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
 
         if self._controller.is_cachable(request=request, response=response):
             await response.aread()
-            await self._storage.store(key, response)
+            await self._storage.store(key, response=response, request=request)
 
         response.extensions["from_cache"] = False  # type: ignore[index]
         return response

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -51,10 +51,12 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
             extensions=request.extensions,
         )
         key = generate_key(httpcore_request)
-        stored_resposne, stored_request = await self._storage.retreive(key)
+        stored_data = await self._storage.retreive(key)
 
-        if stored_resposne:
+        if stored_data:
             # Try using the stored response if it was discovered.
+
+            stored_resposne, stored_request = stored_data
 
             res = self._controller.construct_response_from_cache(
                 request=httpcore_request, response=stored_resposne

--- a/hishel/_serializers.py
+++ b/hishel/_serializers.py
@@ -39,11 +39,21 @@ class PickleSerializer(BaseSerializer):
                 if key in KNOWN_RESPONSE_EXTENSIONS
             },
         )
-        return pickle.dumps(clone_response)
+        clone_request = Request(
+            method=request.method,
+            url=normalized_url(request.url),
+            headers=request.headers,
+            extensions={
+                key: value
+                for key, value in request.extensions.items()
+                if key in KNOWN_REQUEST_EXTENSIONS
+            },
+        )
+        return pickle.dumps((clone_response, clone_request))
 
     def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request]:
         assert isinstance(data, bytes)
-        return tp.cast(Response, pickle.loads(data))
+        return tp.cast(tp.Tuple[Response, Request], pickle.loads(data))
 
     @property
     def is_binary(self) -> bool:  # pragma: no cover

--- a/hishel/_serializers.py
+++ b/hishel/_serializers.py
@@ -4,7 +4,8 @@ import pickle
 import typing as tp
 
 import yaml
-from httpcore import Response, Request
+from httpcore import Request, Response
+
 from hishel._utils import normalized_url
 
 HEADERS_ENCODING = "iso-8859-1"
@@ -66,7 +67,7 @@ class JSONSerializer(BaseSerializer):
         }
 
         request_dict = {
-            "method": request.method.decode('ascii'),
+            "method": request.method.decode("ascii"),
             "url": normalized_url(request.url),
             "headers": [
                 (key.decode(HEADERS_ENCODING), value.decode(HEADERS_ENCODING))
@@ -79,18 +80,15 @@ class JSONSerializer(BaseSerializer):
             },
         }
 
-        full_json = {
-            "response": response_dict,
-            "request": request_dict
-        }
+        full_json = {"response": response_dict, "request": request_dict}
 
         return json.dumps(full_json, indent=4)
 
     def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request]:
         full_json = json.loads(data)
 
-        response_dict = full_json['response']
-        request_dict = full_json['request']
+        response_dict = full_json["response"]
+        request_dict = full_json["request"]
 
         response = Response(
             status=response_dict["status"],
@@ -147,7 +145,7 @@ class YAMLSerializer(BaseSerializer):
     def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request]:
         response_dict = yaml.safe_load(data)
 
-        response = Response(
+        Response(
             status=response_dict["status"],
             headers=[
                 (key.encode(HEADERS_ENCODING), value.encode(HEADERS_ENCODING))

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -31,10 +31,12 @@ class CacheConnectionPool(RequestInterface):
 
     def handle_request(self, request: Request) -> Response:
         key = generate_key(request)
-        stored_resposne, stored_request = self._storage.retreive(key)
+        stored_data = self._storage.retreive(key)
 
-        if stored_resposne:
+        if stored_data:
             # Try using the stored response if it was discovered.
+
+            stored_resposne, stored_request = stored_data
 
             res = self._controller.construct_response_from_cache(
                 request=request, response=stored_resposne
@@ -56,7 +58,7 @@ class CacheConnectionPool(RequestInterface):
                 )
 
                 full_response.read()
-                self._storage.store(key, response=response, request=request)
+                self._storage.store(key, response=full_response, request=request)
                 full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
                 return full_response
 

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -31,7 +31,7 @@ class CacheConnectionPool(RequestInterface):
 
     def handle_request(self, request: Request) -> Response:
         key = generate_key(request)
-        stored_resposne = self._storage.retreive(key)
+        stored_resposne, stored_request = self._storage.retreive(key)
 
         if stored_resposne:
             # Try using the stored response if it was discovered.
@@ -56,7 +56,7 @@ class CacheConnectionPool(RequestInterface):
                 )
 
                 full_response.read()
-                self._storage.store(key, full_response)
+                self._storage.store(key, response=response, request=request)
                 full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
                 return full_response
 
@@ -64,7 +64,7 @@ class CacheConnectionPool(RequestInterface):
 
         if self._controller.is_cachable(request=request, response=response):
             response.read()
-            self._storage.store(key, response)
+            self._storage.store(key, response=response, request=request)
 
         response.extensions["from_cache"] = False  # type: ignore[index]
         return response

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -51,7 +51,7 @@ class CacheTransport(httpx.BaseTransport):
             extensions=request.extensions,
         )
         key = generate_key(httpcore_request)
-        stored_resposne = self._storage.retreive(key)
+        stored_resposne, stored_request = self._storage.retreive(key)
 
         if stored_resposne:
             # Try using the stored response if it was discovered.
@@ -97,7 +97,9 @@ class CacheTransport(httpx.BaseTransport):
                 )
 
                 full_response.read()
-                self._storage.store(key, full_response)
+                self._storage.store(
+                    key, response=full_response, request=httpcore_request
+                )
 
                 assert isinstance(full_response.stream, tp.Iterable)
                 full_response.extensions["from_cache"] = (  # type: ignore[index]
@@ -123,7 +125,9 @@ class CacheTransport(httpx.BaseTransport):
         if self._controller.is_cachable(
             request=httpcore_request, response=httpcore_response
         ):
-            self._storage.store(key, httpcore_response)
+            self._storage.store(
+                key, response=httpcore_response, request=httpcore_request
+            )
 
         response.extensions["from_cache"] = False  # type: ignore[index]
         return Response(

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -51,10 +51,12 @@ class CacheTransport(httpx.BaseTransport):
             extensions=request.extensions,
         )
         key = generate_key(httpcore_request)
-        stored_resposne, stored_request = self._storage.retreive(key)
+        stored_data = self._storage.retreive(key)
 
-        if stored_resposne:
+        if stored_data:
             # Try using the stored response if it was discovered.
+
+            stored_resposne, stored_request = stored_data
 
             res = self._controller.construct_response_from_cache(
                 request=httpcore_request, response=stored_resposne

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -16,9 +16,9 @@ async def test_filestorage(use_temp_dir):
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(key, response)
+    await storage.store(key, response=response, request=request)
 
-    storead_response = await storage.retreive(key)
+    storead_response, _ = await storage.retreive(key)
     assert storead_response is not None
     storead_response.read()
     assert isinstance(storead_response, Response)
@@ -38,9 +38,9 @@ async def test_redisstorage():
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(key, response)
+    await storage.store(key, response=response, request=request)
 
-    storead_response = await storage.retreive(key)
+    storead_response, _ = await storage.retreive(key)
     assert storead_response is not None
     storead_response.read()
     assert isinstance(storead_response, Response)
@@ -61,10 +61,10 @@ async def test_filestorage_expired():
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(first_key, response)
+    await storage.store(first_key, response=response, request=first_request)
 
     await asleep(2)
-    await storage.store(second_key, response)
+    await storage.store(second_key, response=response, request=second_request)
 
     assert await storage.retreive(first_key) is None
 
@@ -81,9 +81,9 @@ async def test_redisstorage_expired():
     response = Response(200, headers=[], content=b"test")
     await response.aread()
 
-    await storage.store(first_key, response)
+    await storage.store(first_key, response=response, request=first_request)
 
     await asleep(2)
-    await storage.store(second_key, response)
+    await storage.store(second_key, response=response, request=second_request)
 
     assert await storage.retreive(first_key) is None

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -18,13 +18,14 @@ async def test_filestorage(use_temp_dir):
 
     await storage.store(key, response=response, request=request)
 
-    storead_response, _ = await storage.retreive(key)
-    assert storead_response is not None
-    storead_response.read()
-    assert isinstance(storead_response, Response)
-    assert storead_response.status == 200
-    assert storead_response.headers == []
-    assert storead_response.content == b"test"
+    stored_data = await storage.retreive(key)
+    assert stored_data is not None
+    stored_response, stored_request = stored_data
+    stored_response.read()
+    assert isinstance(stored_response, Response)
+    assert stored_response.status == 200
+    assert stored_response.headers == []
+    assert stored_response.content == b"test"
 
 
 @pytest.mark.asyncio
@@ -40,13 +41,14 @@ async def test_redisstorage():
 
     await storage.store(key, response=response, request=request)
 
-    storead_response, _ = await storage.retreive(key)
-    assert storead_response is not None
-    storead_response.read()
-    assert isinstance(storead_response, Response)
-    assert storead_response.status == 200
-    assert storead_response.headers == []
-    assert storead_response.content == b"test"
+    stored_data = await storage.retreive(key)
+    assert stored_data is not None
+    stored_response, stored_request = stored_data
+    stored_response.read()
+    assert isinstance(stored_response, Response)
+    assert stored_response.status == 200
+    assert stored_response.headers == []
+    assert stored_response.content == b"test"
 
 
 @pytest.mark.asyncio

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -16,9 +16,9 @@ def test_filestorage(use_temp_dir):
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(key, response)
+    storage.store(key, response=response, request=request)
 
-    storead_response = storage.retreive(key)
+    storead_response, _ = storage.retreive(key)
     assert storead_response is not None
     storead_response.read()
     assert isinstance(storead_response, Response)
@@ -38,9 +38,9 @@ def test_redisstorage():
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(key, response)
+    storage.store(key, response=response, request=request)
 
-    storead_response = storage.retreive(key)
+    storead_response, _ = storage.retreive(key)
     assert storead_response is not None
     storead_response.read()
     assert isinstance(storead_response, Response)
@@ -61,10 +61,10 @@ def test_filestorage_expired():
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(first_key, response)
+    storage.store(first_key, response=response, request=first_request)
 
     sleep(2)
-    storage.store(second_key, response)
+    storage.store(second_key, response=response, request=second_request)
 
     assert storage.retreive(first_key) is None
 
@@ -81,9 +81,9 @@ def test_redisstorage_expired():
     response = Response(200, headers=[], content=b"test")
     response.read()
 
-    storage.store(first_key, response)
+    storage.store(first_key, response=response, request=first_request)
 
     sleep(2)
-    storage.store(second_key, response)
+    storage.store(second_key, response=response, request=second_request)
 
     assert storage.retreive(first_key) is None

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -18,13 +18,14 @@ def test_filestorage(use_temp_dir):
 
     storage.store(key, response=response, request=request)
 
-    storead_response, _ = storage.retreive(key)
-    assert storead_response is not None
-    storead_response.read()
-    assert isinstance(storead_response, Response)
-    assert storead_response.status == 200
-    assert storead_response.headers == []
-    assert storead_response.content == b"test"
+    stored_data = storage.retreive(key)
+    assert stored_data is not None
+    stored_response, stored_request = stored_data
+    stored_response.read()
+    assert isinstance(stored_response, Response)
+    assert stored_response.status == 200
+    assert stored_response.headers == []
+    assert stored_response.content == b"test"
 
 
 
@@ -40,13 +41,14 @@ def test_redisstorage():
 
     storage.store(key, response=response, request=request)
 
-    storead_response, _ = storage.retreive(key)
-    assert storead_response is not None
-    storead_response.read()
-    assert isinstance(storead_response, Response)
-    assert storead_response.status == 200
-    assert storead_response.headers == []
-    assert storead_response.content == b"test"
+    stored_data = storage.retreive(key)
+    assert stored_data is not None
+    stored_response, stored_request = stored_data
+    stored_response.read()
+    assert isinstance(stored_response, Response)
+    assert stored_response.status == 200
+    assert stored_response.headers == []
+    assert stored_response.content == b"test"
 
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,7 +1,8 @@
-from httpcore import Response, Request
+from httpcore import Request, Response
 
 from hishel._serializers import JSONSerializer, PickleSerializer, YAMLSerializer
 from hishel._utils import normalized_url
+
 
 def test_pickle_serializer_dumps_and_loads():
     response = Response(
@@ -29,14 +30,11 @@ def test_pickle_serializer_dumps_and_loads():
 
 def test_dict_serializer_dumps():
     request = Request(
-        method="GET", 
+        method="GET",
         url="https://example.com",
-        headers=[
-            (b'Accept-Encoding', b'gzip')
-        ],
-        extensions={
-            "sni_hostname": "example.com"
-        })
+        headers=[(b"Accept-Encoding", b"gzip")],
+        extensions={"sni_hostname": "example.com"},
+    )
     response = Response(
         status=200,
         headers=[
@@ -51,39 +49,39 @@ def test_dict_serializer_dumps():
 
     assert full_json == "\n".join(
         [
-            '{',
+            "{",
             '    "response": {',
             '        "status": 200,',
             '        "headers": [',
-            '            [',
+            "            [",
             '                "Content-Type",',
             '                "application/json"',
-            '            ],',
-            '            [',
+            "            ],",
+            "            [",
             '                "Transfer-Encoding",',
             '                "chunked"',
-            '            ]',
-            '        ],',
+            "            ]",
+            "        ],",
             '        "content": "dGVzdA==",',
             '        "extensions": {',
             '            "reason_phrase": "OK",',
             '            "http_version": "HTTP/1.1"',
-            '        }',
-            '    },',
+            "        }",
+            "    },",
             '    "request": {',
             '        "method": "GET",',
             '        "url": "https://example.com/",',
             '        "headers": [',
-            '            [',
+            "            [",
             '                "Accept-Encoding",',
             '                "gzip"',
-            '            ]',
-            '        ],',
+            "            ]",
+            "        ],",
             '        "extensions": {',
             '            "sni_hostname": "example.com"',
-            '        }',
-            '    }',
-            '}',
+            "        }",
+            "    }",
+            "}",
         ]
     )
 
@@ -91,39 +89,39 @@ def test_dict_serializer_dumps():
 def test_dict_serializer_loads():
     raw_response = "\n".join(
         [
-            '{',
+            "{",
             '    "response": {',
             '        "status": 200,',
             '        "headers": [',
-            '            [',
+            "            [",
             '                "Content-Type",',
             '                "application/json"',
-            '            ],',
-            '            [',
+            "            ],",
+            "            [",
             '                "Transfer-Encoding",',
             '                "chunked"',
-            '            ]',
-            '        ],',
+            "            ]",
+            "        ],",
             '        "content": "dGVzdA==",',
             '        "extensions": {',
             '            "reason_phrase": "OK",',
             '            "http_version": "HTTP/1.1"',
-            '        }',
-            '    },',
+            "        }",
+            "    },",
             '    "request": {',
             '        "method": "GET",',
             '        "url": "https://example.com/",',
             '        "headers": [',
-            '            [',
+            "            [",
             '                "Accept-Encoding",',
             '                "gzip"',
-            '            ]',
-            '        ],',
+            "            ]",
+            "        ],",
             '        "extensions": {',
             '            "sni_hostname": "example.com"',
-            '        }',
-            '    }',
-            '}',
+            "        }",
+            "    }",
+            "}",
         ]
     )
 
@@ -137,15 +135,10 @@ def test_dict_serializer_loads():
     assert response.content == b"test"
     assert response.extensions == {"http_version": b"HTTP/1.1", "reason_phrase": b"OK"}
 
-
-    assert request.method == b'GET'
+    assert request.method == b"GET"
     assert normalized_url(request.url) == "https://example.com/"
-    assert request.headers == [
-        (b'Accept-Encoding', b'gzip')
-    ]
-    assert request.extensions == {
-        "sni_hostname": "example.com"
-    }
+    assert request.headers == [(b"Accept-Encoding", b"gzip")]
+    assert request.extensions == {"sni_hostname": "example.com"}
 
 
 def test_yaml_serializer_dumps():


### PR DESCRIPTION
Hishel currently stores only responses, but in the future it will be useful to store the request as well as some metadata.

We also require the original requests in order to support the Vary header.

This PR simply modifies the serializers' behavior; they should accept and dump the request object in the same way that they do the responses.

I may add some metadata to the stored responses in the future (or in this pull request), such as when it was created and so on.