### PR TITLE
Version 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## development
+## 0.0.6 (7/29/2023)
 
 - Fix `Vary` header validation. (#8)
 - Dump original requests with the responses (#7) 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2020, Karen Petrosyan.
+Copyright © 2023, Karen Petrosyan.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -4,4 +4,4 @@ from ._headers import *  # noqa: F403
 from ._serializers import *  # noqa: F403
 from ._sync import *  # noqa: F403
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"


### PR DESCRIPTION
# Changelog

## 0.0.6 (7/29/2023)

- Fix `Vary` header validation. (#8)
- Dump original requests with the responses (#7) 
