### PR TITLE
Add support for Heuristic Freshness

### DIFF
--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -132,7 +132,7 @@ class Controller:
         response_cache_control = parse_cache_control(
             extract_header_values_decoded(response.headers, b"cache-control")
         )
-
+        
         # the response status code is final
         if response.status // 100 == 1:
             return False

--- a/hishel/_headers.py
+++ b/hishel/_headers.py
@@ -1,4 +1,6 @@
 import string
+
+import typing as tp
 from typing import Any, Dict, List, Optional, Union
 
 from ._exceptions import ParseError, ValidationError
@@ -58,7 +60,10 @@ def normalize_directive(text: str) -> str:
     return text.replace("-", "_")
 
 
-def parse_cache_control(cache_control_values: List[str]) -> "CacheControl":
+def parse_cache_control(cache_control_values: List[str]) -> tp.Optional["CacheControl"]:
+    if not cache_control_values:
+        return None
+    
     directives = {}
 
     for cache_control_value in cache_control_values:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -83,6 +83,16 @@ def test_is_cachable_for_no_store():
     assert not controller.is_cachable(request=request, response=resposne)
 
 
+def test_is_cachable_without_cachecontrol():
+    controller = Controller(cache_heuristically=True)
+
+    request = Request(b"GET", b"https://example.com", headers=[])
+
+    resposne = Response(200, headers=[(b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT")])
+
+    assert controller.is_cachable(request=request, response=resposne)
+
+
 def test_get_freshness_lifetime():
     response = Response(status=200, headers=[(b"Cache-Control", b"max-age=3600")])
 


### PR DESCRIPTION
Because some servers do not supply an expiration headers, browsers can calculate the heuristic freshness based on other response headers such as "Last-Modified"

Steps

- [x] Add `get_heuristic_freshness` function according to https://www.rfc-editor.org/rfc/rfc9111.html#name-calculating-heuristic-fresh
- [x] Add tests
- [x] Add changelog