### PR TITLE
🏺 Add support for Heuristic Freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## development
+
+- Add support for `Heuristic Freshness`. (#10)
+
 ## 0.0.6 (7/29/2023)
 
 - Fix `Vary` header validation. (#8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## development
 
-- Add support for `Heuristic Freshness`. (#10)
+- Add support for `Heuristic Freshness`. (#11)
 
 ## 0.0.6 (7/29/2023)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -291,6 +291,21 @@ def test_construct_response_from_cache_with_no_cache():
     assert isinstance(conditional_request, Request)
 
 
+def test_construct_response_heuristically():
+    controller = Controller()
+    response = Response(
+        status=200,
+        headers=[(b'Date', b'Mon, 25 Aug 2015 12:00:00 GMT')]
+    )
+    original_request = Request("GET", "https://example.com")
+    request = Request("GET", "https://example.com")
+
+    response = controller.construct_response_from_cache(
+        request=request, response=response, original_request=original_request
+    )
+
+    assert isinstance(response, Response)
+
 def test_handle_validation_response_changed():
     controller = Controller()
 


### PR DESCRIPTION
Because some servers do not supply an expiration headers, browsers can calculate the heuristic freshness based on other response headers such as "Last-Modified"

Steps

- [x] Add `get_heuristic_freshness` function according to https://www.rfc-editor.org/rfc/rfc9111.html#name-calculating-heuristic-fresh
- [x] Add tests
- [x] Add changelog