### PR TITLE
Handle import errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for `Heuristic Freshness`. (#11)
 - Change `Controller.cache_heuristically` to `Controller.allow_heuristics`. (#12)
+- Handle import errors. (#13)
 
 ## 0.0.6 (7/29/2023)
 

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -17,7 +17,7 @@ __all__ = ("AsyncFileStorage", "AsyncRedisStorage")
 
 try:
     import redis.asyncio as redis
-except ImportError:
+except ImportError:  # pragma: no cover
     redis = None  # type: ignore
 
 
@@ -101,7 +101,7 @@ class AsyncRedisStorage(AsyncBaseStorage):
         client: tp.Optional["redis.Redis"] = None,  # type: ignore
         ttl: tp.Optional[int] = None,
     ) -> None:
-        if redis is None:
+        if redis is None:  # pragma: no cover
             raise RuntimeError(
                 (
                     f"The `{type(self).__name__}` was used, but the required packages were not found. "

--- a/hishel/_async/_storages.py
+++ b/hishel/_async/_storages.py
@@ -18,7 +18,7 @@ __all__ = ("AsyncFileStorage", "AsyncRedisStorage")
 try:
     import redis.asyncio as redis
 except ImportError:
-    redis = None
+    redis = None  # type: ignore
 
 
 class AsyncBaseStorage:

--- a/hishel/_serializers.py
+++ b/hishel/_serializers.py
@@ -9,7 +9,7 @@ from hishel._utils import normalized_url
 
 try:
     import yaml
-except ImportError:
+except ImportError:  # pragma: no cover
     yaml = None  # type: ignore
 
 HEADERS_ENCODING = "iso-8859-1"
@@ -141,7 +141,7 @@ class JSONSerializer(BaseSerializer):
 
 class YAMLSerializer(BaseSerializer):
     def dumps(self, response: Response, request: Request) -> tp.Union[str, bytes]:
-        if yaml is None:
+        if yaml is None:  # pragma: no cover
             raise RuntimeError(
                 (
                     f"The `{type(self).__name__}` was used, but the required packages were not found. "
@@ -182,7 +182,7 @@ class YAMLSerializer(BaseSerializer):
         return yaml.safe_dump(full_json, sort_keys=False)
 
     def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request]:
-        if yaml is None:
+        if yaml is None:  # pragma: no cover
             raise RuntimeError(
                 (
                     f"The `{type(self).__name__}` was used, but the required packages were not found. "

--- a/hishel/_serializers.py
+++ b/hishel/_serializers.py
@@ -10,7 +10,7 @@ from hishel._utils import normalized_url
 try:
     import yaml
 except ImportError:
-    yaml = None
+    yaml = None  # type: ignore
 
 HEADERS_ENCODING = "iso-8859-1"
 KNOWN_RESPONSE_EXTENSIONS = ("http_version", "reason_phrase")

--- a/hishel/_serializers.py
+++ b/hishel/_serializers.py
@@ -3,10 +3,14 @@ import json
 import pickle
 import typing as tp
 
-import yaml
 from httpcore import Request, Response
 
 from hishel._utils import normalized_url
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
 
 HEADERS_ENCODING = "iso-8859-1"
 KNOWN_RESPONSE_EXTENSIONS = ("http_version", "reason_phrase")
@@ -137,6 +141,14 @@ class JSONSerializer(BaseSerializer):
 
 class YAMLSerializer(BaseSerializer):
     def dumps(self, response: Response, request: Request) -> tp.Union[str, bytes]:
+        if yaml is None:
+            raise RuntimeError(
+                (
+                    f"The `{type(self).__name__}` was used, but the required packages were not found. "
+                    "Check that you have `Hishel` installed with the `yaml` extension as shown.\n"
+                    "```pip install hishel[yaml]```"
+                )
+            )
         response_dict = {
             "status": response.status,
             "headers": [
@@ -170,6 +182,15 @@ class YAMLSerializer(BaseSerializer):
         return yaml.safe_dump(full_json, sort_keys=False)
 
     def loads(self, data: tp.Union[str, bytes]) -> tp.Tuple[Response, Request]:
+        if yaml is None:
+            raise RuntimeError(
+                (
+                    f"The `{type(self).__name__}` was used, but the required packages were not found. "
+                    "Check that you have `Hishel` installed with the `yaml` extension as shown.\n"
+                    "```pip install hishel[yaml]```"
+                )
+            )
+
         full_json = yaml.safe_load(data)
 
         response_dict = full_json["response"]

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -17,7 +17,7 @@ __all__ = ("FileStorage", "RedisStorage")
 
 try:
     import redis
-except ImportError:
+except ImportError:  # pragma: no cover
     redis = None  # type: ignore
 
 
@@ -101,7 +101,7 @@ class RedisStorage(BaseStorage):
         client: tp.Optional["redis.Redis"] = None,  # type: ignore
         ttl: tp.Optional[int] = None,
     ) -> None:
-        if redis is None:
+        if redis is None:  # pragma: no cover
             raise RuntimeError(
                 (
                     f"The `{type(self).__name__}` was used, but the required packages were not found. "

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -18,7 +18,7 @@ __all__ = ("FileStorage", "RedisStorage")
 try:
     import redis
 except ImportError:
-    redis = None
+    redis = None  # type: ignore
 
 
 class BaseStorage:

--- a/hishel/_sync/_storages.py
+++ b/hishel/_sync/_storages.py
@@ -3,7 +3,6 @@ import time
 import typing as tp
 from pathlib import Path
 
-import redis
 from httpcore import Request, Response
 
 from hishel._serializers import BaseSerializer
@@ -15,6 +14,11 @@ from .._synchronization import Lock
 logger = logging.getLogger("hishel.storages")
 
 __all__ = ("FileStorage", "RedisStorage")
+
+try:
+    import redis
+except ImportError:
+    redis = None
 
 
 class BaseStorage:
@@ -94,9 +98,17 @@ class RedisStorage(BaseStorage):
     def __init__(
         self,
         serializer: tp.Optional[BaseSerializer] = None,
-        client: tp.Optional[redis.Redis] = None,  # type: ignore
+        client: tp.Optional["redis.Redis"] = None,  # type: ignore
         ttl: tp.Optional[int] = None,
     ) -> None:
+        if redis is None:
+            raise RuntimeError(
+                (
+                    f"The `{type(self).__name__}` was used, but the required packages were not found. "
+                    "Check that you have `Hishel` installed with the `redis` extension as shown.\n"
+                    "```pip install hishel[redis]```"
+                )
+            )
         super().__init__(serializer)
 
         if client is None:


### PR DESCRIPTION
When an extension, such as a yaml module, cannot be imported, we should suppress the import error because it is an optional package.

Extensions to handle

- [x] yaml extension (pip install hishel[yaml])
- [x] redis extension (pip install hishel[redis]) 