### PR TITLE
Skip redis tests if the server was not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## development
+
+- Skip redis tests if the server was not found. (#16)
+
 ## 0.0.7 (7/30/2023)
 
 - Add support for `Heuristic Freshness`. (#11)

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -11,7 +11,7 @@ def is_redis_down() -> bool:
     connection = redis.Redis()
     try:
         return not connection.ping()
-    except BaseException:
+    except BaseException:  # pragma: no cover
         return True
 
 

--- a/tests/_async/test_storages.py
+++ b/tests/_async/test_storages.py
@@ -5,6 +5,16 @@ from hishel import AsyncFileStorage, AsyncRedisStorage
 from hishel._utils import asleep, generate_key
 
 
+def is_redis_down() -> bool:
+    import redis
+
+    connection = redis.Redis()
+    try:
+        return not connection.ping()
+    except BaseException:
+        return True
+
+
 @pytest.mark.anyio
 async def test_filestorage(use_temp_dir):
     storage = AsyncFileStorage()
@@ -28,6 +38,7 @@ async def test_filestorage(use_temp_dir):
     assert stored_response.content == b"test"
 
 
+@pytest.mark.skipif(is_redis_down(), reason="Redis server was not found")
 @pytest.mark.asyncio
 async def test_redisstorage():
     storage = AsyncRedisStorage()
@@ -71,6 +82,7 @@ async def test_filestorage_expired():
     assert await storage.retreive(first_key) is None
 
 
+@pytest.mark.skipif(is_redis_down(), reason="Redis server was not found")
 @pytest.mark.asyncio
 async def test_redisstorage_expired():
     storage = AsyncRedisStorage(ttl=1)

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -11,7 +11,7 @@ def is_redis_down() -> bool:
     connection = redis.Redis()
     try:
         return not connection.ping()
-    except BaseException:
+    except BaseException:  # pragma: no cover
         return True
 
 

--- a/tests/_sync/test_storages.py
+++ b/tests/_sync/test_storages.py
@@ -5,6 +5,16 @@ from hishel import FileStorage, RedisStorage
 from hishel._utils import sleep, generate_key
 
 
+def is_redis_down() -> bool:
+    import redis
+
+    connection = redis.Redis()
+    try:
+        return not connection.ping()
+    except BaseException:
+        return True
+
+
 
 def test_filestorage(use_temp_dir):
     storage = FileStorage()
@@ -28,6 +38,7 @@ def test_filestorage(use_temp_dir):
     assert stored_response.content == b"test"
 
 
+@pytest.mark.skipif(is_redis_down(), reason="Redis server was not found")
 
 def test_redisstorage():
     storage = RedisStorage()
@@ -71,6 +82,7 @@ def test_filestorage_expired():
     assert storage.retreive(first_key) is None
 
 
+@pytest.mark.skipif(is_redis_down(), reason="Redis server was not found")
 
 def test_redisstorage_expired():
     storage = RedisStorage(ttl=1)


### PR DESCRIPTION
As long as hishel provides redis tests that require a redis server, when testing locally, you may not have a redis server installed on your workstation, therefore hishel will simply ignore these tests.