### PR TITLE
Add support for request cache-control directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## development
 
+- Add support for request `cache-control` directives. (#42)
 - Drop httpcore dependencie. (#40)
 - Support HTTP methods only if they are defined as cacheable. (#37)
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -555,3 +555,93 @@ client = hishel.CacheClient(controller=controller)
 
 !!! note
     Because we already have the response body in our cache, revalidation is very quick.
+
+
+## Request Headers
+
+In addition, you can use the request `Cache-Control` directives defined in [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111#name-request-directives) to make the cache behavior more explicit in some situations.
+
+### max-age
+
+If this directive is present in the request headers, the cache should ignore responses that are older than the specified number.
+
+Example:
+
+```python
+import hishel
+
+client = hishel.CacheClient()
+client.get("https://example.com", headers=[("Cache-Control", "max-age=3600")])
+```
+
+### max-stale
+
+If this directive is present in the request headers, the cache should ignore responses that have exceeded their freshness lifetime by more than the specified number of seconds.
+
+```python
+import hishel
+
+client = hishel.CacheClient()
+client.get("https://example.com", headers=[("Cache-Control", "max-stale=3600")])
+```
+
+### min-fresh
+
+If this directive is present in the request headers, the cache should ignore responses that will not be fresh for at least the number of seconds specified.
+
+```python
+import hishel
+
+client = hishel.CacheClient()
+client.get("https://example.com", headers=[("Cache-Control", "min-fresh=3600")])
+```
+
+### no-cache
+
+If this directive is present in the request headers, the cache should not use the response to this request unless it has been validated.
+
+```python
+import hishel
+
+client = hishel.CacheClient()
+client.get("https://example.com", headers=[("Cache-Control", "no-cache")])
+```
+
+### no-store
+
+If this directive is present in the request headers, the cache should not save the response to this request.
+
+```python
+import hishel
+
+client = hishel.CacheClient()
+client.get("https://example.com", headers=[("Cache-Control", "no-store")])
+```
+
+### only-if-cached
+
+If this directive is present in the request headers, the cache should either use the cached response or return the 504 status code.
+
+!!! note
+    It is guaranteed that the client will not make any requests; instead, it will try to find a response from the cache that can be used for this request.
+
+```python
+>>> import hishel
+>>> 
+>>> client = hishel.CacheClient()
+>>> response = client.get("https://example.com", headers=[("Cache-Control", "only-if-cached")])
+>>> response
+<Response [504 Gateway Timeout]>
+```
+
+or
+
+```python
+>>> import hishel
+>>> 
+>>> client = hishel.CacheClient()
+>>> client.get("https://google.com")  # will cache
+>>> response = client.get("https://google.com", headers=[("Cache-Control", "only-if-cached")])
+>>> response
+<Response [301 Moved Permanently]>
+```

--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -163,13 +163,16 @@ class Controller:
         response_cache_control = parse_cache_control(
             extract_header_values_decoded(response.headers, b"cache-control")
         )
+        request_cache_control = parse_cache_control(
+            extract_header_values_decoded(request.headers, b"cache-control")
+        )
 
         # the response status code is final
         if response.status // 100 == 1:
             return False
 
         # the no-store cache directive is not present in the response (see Section 5.2.2.5)
-        if response_cache_control.no_store:
+        if response_cache_control.no_store or request_cache_control.no_store:
             return False
 
         expires_presents = header_presents(response.headers, b"expires")
@@ -294,6 +297,7 @@ class Controller:
             self._always_revalidate
             or response_cache_control.no_cache
             or response_cache_control.must_revalidate
+            or request_cache_control.no_cache
         ):
             self._make_request_conditional(request=request, response=response)
             return request

--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -311,6 +311,18 @@ class Controller:
         age = get_age(response, self._clock)
         is_fresh = freshness_lifetime > age
 
+        # The max-stale request directive indicates that the
+        # client will accept a response that has exceeded its freshness lifetime.
+        # If a value is present, then the client is willing to accept a response
+        # that has exceeded its freshness lifetime by no more than the specified
+        # number of seconds. If no value is assigned to max-stale, then
+        # the client will accept a stale response of any age.
+        if not is_fresh and request_cache_control.max_stale is not None:
+            exceeded_freshness_lifetime = age - freshness_lifetime
+
+            if request_cache_control.max_stale < exceeded_freshness_lifetime:
+                return None
+
         # The max-age request directive indicates that
         # the client prefers a response whose age is
         # less than or equal to the specified number of seconds.

--- a/hishel/_controller.py
+++ b/hishel/_controller.py
@@ -311,6 +311,15 @@ class Controller:
         age = get_age(response, self._clock)
         is_fresh = freshness_lifetime > age
 
+        # The min-fresh request directive indicates that the client
+        # prefers a response whose freshness lifetime is no less than
+        #  its current age plus the specified time in seconds.
+        # That is, the client wants a response that will still
+        # be fresh for at least the specified number of seconds.
+        if request_cache_control.min_fresh is not None:
+            if freshness_lifetime < (age + request_cache_control.min_fresh):
+                return None
+
         # The max-stale request directive indicates that the
         # client will accept a response that has exceeded its freshness lifetime.
         # If a value is present, then the client is willing to accept a response

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -7,13 +7,18 @@ from httpcore._exceptions import ConnectError
 from httpcore._models import Request, Response
 
 from .._controller import Controller, allowed_stale
+from .._headers import parse_cache_control
 from .._serializers import JSONSerializer, Metadata
-from .._utils import generate_key
+from .._utils import extract_header_values_decoded, generate_key
 from ._storages import BaseStorage, FileStorage
 
 T = tp.TypeVar("T")
 
 __all__ = ("CacheConnectionPool",)
+
+
+def generate_504() -> Response:
+    return Response(status=504)
 
 
 class CacheConnectionPool(RequestInterface):
@@ -54,6 +59,13 @@ class CacheConnectionPool(RequestInterface):
         key = generate_key(request)
         stored_data = self._storage.retreive(key)
 
+        request_cache_control = parse_cache_control(
+            extract_header_values_decoded(request.headers, b"Cache-Control")
+        )
+
+        if request_cache_control.only_if_cached and not stored_data:
+            return generate_504()
+
         if stored_data:
             # Try using the stored response if it was discovered.
 
@@ -77,6 +89,9 @@ class CacheConnectionPool(RequestInterface):
                 )
                 res.extensions["from_cache"] = True  # type: ignore[index]
                 return res
+
+            if request_cache_control.only_if_cached:
+                return generate_504()
 
             if isinstance(res, Request):
                 # Re-validating the response.

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -8,9 +8,10 @@ from httpx import Request, Response
 from httpx._exceptions import ConnectError
 from httpx._transports.default import ResponseStream
 
-from hishel._utils import generate_key, normalized_url
+from hishel._utils import extract_header_values_decoded, generate_key, normalized_url
 
 from .._controller import Controller, allowed_stale
+from .._headers import parse_cache_control
 from .._serializers import JSONSerializer, Metadata
 from ._storages import BaseStorage, FileStorage
 
@@ -22,6 +23,10 @@ __all__ = ("CacheTransport",)
 
 def fake_stream(content: bytes) -> tp.Iterable[bytes]:
     yield content
+
+
+def generate_504() -> Response:
+    return Response(status_code=504)
 
 
 class CacheTransport(httpx.BaseTransport):
@@ -74,6 +79,13 @@ class CacheTransport(httpx.BaseTransport):
         key = generate_key(httpcore_request)
         stored_data = self._storage.retreive(key)
 
+        request_cache_control = parse_cache_control(
+            extract_header_values_decoded(request.headers.raw, b"Cache-Control")
+        )
+
+        if request_cache_control.only_if_cached and not stored_data:
+            return generate_504()
+
         if stored_data:
             # Try using the stored response if it was discovered.
 
@@ -102,6 +114,9 @@ class CacheTransport(httpx.BaseTransport):
                     stream=ResponseStream(fake_stream(stored_resposne.content)),
                     extensions=res.extensions,
                 )
+
+            if request_cache_control.only_if_cached:
+                return generate_504()
 
             if isinstance(res, httpcore.Request):
                 # Re-validating the response.

--- a/tests/_async/test_transport.py
+++ b/tests/_async/test_transport.py
@@ -122,3 +122,58 @@ async def test_transport_stale_response_with_connecterror(use_temp_dir):
             await cache_transport.handle_async_request(request)
             response = await cache_transport.handle_async_request(request)
             assert response.extensions["from_cache"]
+
+
+@pytest.mark.anyio
+async def test_transport_with_only_if_cached_directive_without_stored_response(
+    use_temp_dir,
+):
+    controller = hishel.Controller()
+
+    async with hishel.MockAsyncTransport() as transport:
+        async with hishel.AsyncCacheTransport(
+            transport=transport, controller=controller
+        ) as cache_transport:
+            response = await cache_transport.handle_async_request(
+                httpx.Request(
+                    "GET",
+                    "https://www.example.com",
+                    headers=[(b"Cache-Control", b"only-if-cached")],
+                )
+            )
+            assert response.status_code == 504
+
+
+@pytest.mark.anyio
+async def test_transport_with_only_if_cached_directive_with_stored_response(
+    use_temp_dir,
+):
+    controller = hishel.Controller()
+
+    async with hishel.MockAsyncTransport() as transport:
+        transport.add_responses(
+            [
+                httpx.Response(
+                    200,
+                    headers=[
+                        (b"Cache-Control", b"max-age=3600"),
+                        (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+                    ],
+                    content=b"test",
+                ),
+            ]
+        )
+        async with hishel.AsyncCacheTransport(
+            transport=transport, controller=controller
+        ) as cache_transport:
+            await cache_transport.handle_async_request(
+                httpx.Request("GET", "https://www.example.com")
+            )
+            response = await cache_transport.handle_async_request(
+                httpx.Request(
+                    "GET",
+                    "https://www.example.com",
+                    headers=[(b"Cache-Control", b"only-if-cached")],
+                )
+            )
+            assert response.status_code == 504

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -697,3 +697,29 @@ def test_no_cache_request_directive():
         original_request=original_request, request=request, response=response
     )
     assert isinstance(cached_response, Request)
+
+
+def test_no_store_request_directive():
+    request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", b"no-store"),
+        ],
+    )
+
+    response = Response(
+        status=200,
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", "max-age=4000"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+        ],
+    )
+
+    controller = Controller()
+
+    assert not controller.is_cachable(request=request, response=response)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -491,3 +491,87 @@ def test_vary_validation_value_wildcard():
     assert not controller._validate_vary(
         request=request, response=response, original_request=original_request
     )
+
+
+def test_max_age_request_directive():
+    class MockedClock(BaseClock):
+        def now(self) -> int:
+            return 1440507600  # Mon, 25 Aug 2015 13:00:00 GMT
+
+    original_request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+        ],
+    )
+
+    request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", "max-age=3599, no-cache"),
+        ],
+    )
+
+    response = Response(
+        status=200,
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", "max-age=3600"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+        ],
+    )
+
+    controller = Controller(clock=MockedClock())
+
+    cached_response = controller.construct_response_from_cache(
+        original_request=original_request, request=request, response=response
+    )
+    assert cached_response is None
+
+
+def test_max_age_request_directive_without_max_stale():
+    class MockedClock(BaseClock):
+        def now(self) -> int:
+            return 1440507600  # Mon, 25 Aug 2015 13:00:00 GMT
+
+    original_request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+        ],
+    )
+
+    request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", "max-age=3600, no-cache"),
+        ],
+    )
+
+    response = Response(
+        status=200,
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", "max-age=600"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+        ],
+    )
+
+    controller = Controller(clock=MockedClock())
+
+    cached_response = controller.construct_response_from_cache(
+        original_request=original_request, request=request, response=response
+    )
+    assert cached_response is None

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -617,3 +617,45 @@ def test_max_stale_request_directive():
         original_request=original_request, request=request, response=response
     )
     assert cached_response is None
+
+
+def test_min_fresh_request_directive():
+    class MockedClock(BaseClock):
+        def now(self) -> int:
+            return 1440507600  # Mon, 25 Aug 2015 13:00:00 GMT
+
+    original_request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+        ],
+    )
+
+    request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", b"min_fresh=10000"),
+        ],
+    )
+
+    response = Response(
+        status=200,
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", "max-age=4000"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+        ],
+    )
+
+    controller = Controller(clock=MockedClock())
+
+    cached_response = controller.construct_response_from_cache(
+        original_request=original_request, request=request, response=response
+    )
+    assert cached_response is None

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -513,7 +513,7 @@ def test_max_age_request_directive():
         headers=[
             (b"Content-Type", b"application/json"),
             (b"Content-Language", b"en-US"),
-            (b"Cache-Control", "max-age=3599, no-cache"),
+            (b"Cache-Control", "max-age=3599"),
         ],
     )
 
@@ -555,7 +555,7 @@ def test_max_age_request_directive_without_max_stale():
         headers=[
             (b"Content-Type", b"application/json"),
             (b"Content-Language", b"en-US"),
-            (b"Cache-Control", "max-age=3600, no-cache"),
+            (b"Cache-Control", "max-age=3600"),
         ],
     )
 
@@ -659,3 +659,41 @@ def test_min_fresh_request_directive():
         original_request=original_request, request=request, response=response
     )
     assert cached_response is None
+
+
+def test_no_cache_request_directive():
+    original_request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+        ],
+    )
+
+    request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", b"no-cache"),
+        ],
+    )
+
+    response = Response(
+        status=200,
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", "max-age=4000"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+        ],
+    )
+
+    controller = Controller()
+
+    cached_response = controller.construct_response_from_cache(
+        original_request=original_request, request=request, response=response
+    )
+    assert isinstance(cached_response, Request)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -575,3 +575,45 @@ def test_max_age_request_directive_without_max_stale():
         original_request=original_request, request=request, response=response
     )
     assert cached_response is None
+
+
+def test_max_stale_request_directive():
+    class MockedClock(BaseClock):
+        def now(self) -> int:
+            return 1440507600  # Mon, 25 Aug 2015 13:00:00 GMT
+
+    original_request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+        ],
+    )
+
+    request = Request(
+        method="GET",
+        url="https://example.com",
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", b"max-stale=2999"),
+        ],
+    )
+
+    response = Response(
+        status=200,
+        headers=[
+            (b"Content-Type", b"application/json"),
+            (b"Content-Language", b"en-US"),
+            (b"Cache-Control", "max-age=600"),
+            (b"Date", b"Mon, 25 Aug 2015 12:00:00 GMT"),
+        ],
+    )
+
+    controller = Controller(clock=MockedClock())
+
+    cached_response = controller.construct_response_from_cache(
+        original_request=original_request, request=request, response=response
+    )
+    assert cached_response is None


### PR DESCRIPTION
Closes #39 

# TODO

- [x] Support [max-age](https://www.rfc-editor.org/rfc/rfc9111.html#name-max-age)
- [x] Support [max-stale](https://www.rfc-editor.org/rfc/rfc9111.html#name-max-stale)
- [x] Support [min-fresh](https://www.rfc-editor.org/rfc/rfc9111.html#name-min-fresh)
- [x] Support [no-cache](https://www.rfc-editor.org/rfc/rfc9111.html#name-no-cache)
- [x] Support  [no-store](https://www.rfc-editor.org/rfc/rfc9111.html#name-no-store)
- [x] Support [only-if-cached](https://www.rfc-editor.org/rfc/rfc9111.html#name-only-if-cached)
- [x] Write documentation