### PR TITLE
Version 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## development
+## 0.0.11 (8/15/2023) 
 
 - Add support for request `cache-control` directives. (#42)
 - Drop httpcore dependencie. (#40)

--- a/hishel/__init__.py
+++ b/hishel/__init__.py
@@ -5,4 +5,4 @@ from ._headers import *  # noqa: F403
 from ._serializers import *  # noqa: F403
 from ._sync import *  # noqa: F403
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"


### PR DESCRIPTION
## 0.0.11 (8/15/2023) 

- Add support for request `cache-control` directives. (#42)
- Drop httpcore dependencie. (#40)
- Support HTTP methods only if they are defined as cacheable. (#37)