### PR TITLE
Add metadata into the response extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## development
+
+- Add metadata into the response extensions. (#56)
+
 ## 0.0.11 (8/15/2023) 
 
 - Add support for request `cache-control` directives. (#42)

--- a/hishel/_async/_pool.py
+++ b/hishel/_async/_pool.py
@@ -88,6 +88,7 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
                     metadata=metadata,
                 )
                 res.extensions["from_cache"] = True  # type: ignore[index]
+                res.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return res
 
             if request_cache_control.only_if_cached:
@@ -103,6 +104,7 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
                         response=stored_resposne
                     ):
                         stored_resposne.extensions["from_cache"] = True  # type: ignore[index]
+                        stored_resposne.extensions["cache_metadata"] = metadata  # type: ignore[index]
                         return stored_resposne
                     raise  # pragma: no cover
                 # Merge headers with the stale response.
@@ -116,6 +118,7 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
                     key, response=full_response, request=request, metadata=metadata
                 )
                 full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
+                full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return full_response
 
         response = await self._pool.handle_async_request(request)

--- a/hishel/_async/_pool.py
+++ b/hishel/_async/_pool.py
@@ -118,7 +118,8 @@ class AsyncCacheConnectionPool(AsyncRequestInterface):
                     key, response=full_response, request=request, metadata=metadata
                 )
                 full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
-                full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
+                if full_response.extensions["from_cache"]:
+                    full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return full_response
 
         response = await self._pool.handle_async_request(request)

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -108,6 +108,7 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
                     metadata=metadata,
                 )
                 res.extensions["from_cache"] = True  # type: ignore[index]
+                res.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return Response(
                     status_code=res.status,
                     headers=res.headers,
@@ -137,6 +138,7 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
                     ):
                         await stored_resposne.aread()
                         stored_resposne.extensions["from_cache"] = True  # type: ignore[index]
+                        stored_resposne.extensions["cache_metadata"] = metadata  # type: ignore[index]
                         return Response(
                             status_code=stored_resposne.status,
                             headers=stored_resposne.headers,
@@ -173,6 +175,7 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
                 full_response.extensions["from_cache"] = (  # type: ignore[index]
                     httpcore_response.status == 304
                 )
+                full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return Response(
                     status_code=full_response.status,
                     headers=full_response.headers,

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -175,7 +175,8 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
                 full_response.extensions["from_cache"] = (  # type: ignore[index]
                     httpcore_response.status == 304
                 )
-                full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
+                if full_response.extensions["from_cache"]:
+                    full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return Response(
                     status_code=full_response.status,
                     headers=full_response.headers,

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -88,6 +88,7 @@ class CacheConnectionPool(RequestInterface):
                     metadata=metadata,
                 )
                 res.extensions["from_cache"] = True  # type: ignore[index]
+                res.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return res
 
             if request_cache_control.only_if_cached:
@@ -103,6 +104,7 @@ class CacheConnectionPool(RequestInterface):
                         response=stored_resposne
                     ):
                         stored_resposne.extensions["from_cache"] = True  # type: ignore[index]
+                        stored_resposne.extensions["cache_metadata"] = metadata  # type: ignore[index]
                         return stored_resposne
                     raise  # pragma: no cover
                 # Merge headers with the stale response.
@@ -116,6 +118,7 @@ class CacheConnectionPool(RequestInterface):
                     key, response=full_response, request=request, metadata=metadata
                 )
                 full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
+                full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return full_response
 
         response = self._pool.handle_request(request)

--- a/hishel/_sync/_pool.py
+++ b/hishel/_sync/_pool.py
@@ -118,7 +118,8 @@ class CacheConnectionPool(RequestInterface):
                     key, response=full_response, request=request, metadata=metadata
                 )
                 full_response.extensions["from_cache"] = response.status == 304  # type: ignore[index]
-                full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
+                if full_response.extensions["from_cache"]:
+                    full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return full_response
 
         response = self._pool.handle_request(request)

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -108,6 +108,7 @@ class CacheTransport(httpx.BaseTransport):
                     metadata=metadata,
                 )
                 res.extensions["from_cache"] = True  # type: ignore[index]
+                res.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return Response(
                     status_code=res.status,
                     headers=res.headers,
@@ -137,6 +138,7 @@ class CacheTransport(httpx.BaseTransport):
                     ):
                         stored_resposne.read()
                         stored_resposne.extensions["from_cache"] = True  # type: ignore[index]
+                        stored_resposne.extensions["cache_metadata"] = metadata  # type: ignore[index]
                         return Response(
                             status_code=stored_resposne.status,
                             headers=stored_resposne.headers,
@@ -173,6 +175,7 @@ class CacheTransport(httpx.BaseTransport):
                 full_response.extensions["from_cache"] = (  # type: ignore[index]
                     httpcore_response.status == 304
                 )
+                full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return Response(
                     status_code=full_response.status,
                     headers=full_response.headers,

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -175,7 +175,8 @@ class CacheTransport(httpx.BaseTransport):
                 full_response.extensions["from_cache"] = (  # type: ignore[index]
                     httpcore_response.status == 304
                 )
-                full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
+                if full_response.extensions["from_cache"]:
+                    full_response.extensions["cache_metadata"] = metadata  # type: ignore[index]
                 return Response(
                     status_code=full_response.status,
                     headers=full_response.headers,


### PR DESCRIPTION
Closes #53 

Example

``` python
import hishel

client = hishel.CacheClient()

response = client.get("https://google.com")
print(response.extensions['cache_metadata'])
```

OUTPUT

{'cache_key': '022869ef584dbb7e7b4b8f4eb70c92b6', 'created_at': datetime.datetime(2023, 8, 23, 5, 52, 3), 'number_of_uses': 25}