### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,13 @@ jobs:
     
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11" ]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12" ]
     
     env: 
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v4.5.0"
         with:
           python-version: "${{ matrix.python-version }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       HISHEL_PYPI: ${{ secrets.HISHEL_PYPI }}
 
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v4"
         with:
           python-version: 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
@@ -42,7 +43,7 @@ redis = [
 ]
 
 [project.urls]
-Homepage = "https://karosis88.github.io/hishel/"
+Homepage = "https://hishel.com"
 Source = "https://github.com/karosis88/hishel"
 
 [tool.hatch.version]


### PR DESCRIPTION
Following https://github.com/encode/httpcore/pull/807 and https://github.com/encode/httpx/pull/2854, we should also add support for Python 3.12.

Thanks to @hugovk

# TODO

- [ ] Add changelog