### PR TITLE
Close the connections after reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for Python 3.12. (#71)
+- Fix connections releasing from the connection pool. (#83)
 
 ## 0.0.12 (8/9/2023)
 

--- a/hishel/_async/_transports.py
+++ b/hishel/_async/_transports.py
@@ -162,6 +162,8 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
                 )
 
                 await full_response.aread()
+                await response.aclose()
+
                 metadata["number_of_uses"] += response.status_code == 304
 
                 await self._storage.store(
@@ -193,6 +195,7 @@ class AsyncCacheTransport(httpx.AsyncBaseTransport):
             extensions=response.extensions,
         )
         await httpcore_response.aread()
+        await httpcore_response.aclose()
 
         if self._controller.is_cachable(
             request=httpcore_request, response=httpcore_response

--- a/hishel/_sync/_transports.py
+++ b/hishel/_sync/_transports.py
@@ -162,6 +162,8 @@ class CacheTransport(httpx.BaseTransport):
                 )
 
                 full_response.read()
+                response.close()
+
                 metadata["number_of_uses"] += response.status_code == 304
 
                 self._storage.store(
@@ -193,6 +195,7 @@ class CacheTransport(httpx.BaseTransport):
             extensions=response.extensions,
         )
         httpcore_response.read()
+        httpcore_response.close()
 
         if self._controller.is_cachable(
             request=httpcore_request, response=httpcore_response


### PR DESCRIPTION
Closes #82 

Hishel should immediately close the response stream after it's read because it would never use that stream.